### PR TITLE
Disable specific ESLint rules for React component properties

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,8 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       'no-unused-vars': 'off',
+      'react/no-unknown-property': 'off',
+      'react/prop-types': 'off',
       'react/jsx-no-target-blank': 'off',
       'react-refresh/only-export-components': [
         'warn',


### PR DESCRIPTION
Disable the `react/no-unknown-property` and `react/prop-types` ESLint rules to streamline the linting process for React components.