### PR TITLE
Update version to 3.9.16 and correct company name casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfolio-v2",
   "private": true,
-  "version": "3.9.15",
+  "version": "3.9.16",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -147,7 +147,7 @@ const shorted_technologies = [
 const experiences = [
 	{
 		title: "Intern Software Engineer",
-		company_name: "icieos PVT LDT",
+		company_name: "ICIEOS Pvt Ltd.",
 		icon: icieos,
 		iconBg: "#E6DEDD",
 		date: "March 2025 - Current",


### PR DESCRIPTION
Update the package version to 3.9.16 and fix the casing of the company name in the experiences section.